### PR TITLE
Turns the version into a defaultable tuple struct

### DIFF
--- a/src/dmi/icon.rs
+++ b/src/dmi/icon.rs
@@ -397,5 +397,7 @@ impl Default for IconState {
 pub struct DmiVersion(String);
 
 impl Default for DmiVersion {
-	fn default() -> Self {DmiVersion("4.0".to_string())}
+	fn default() -> Self {
+		DmiVersion("4.0".to_string())
+	}
 }

--- a/src/dmi/icon.rs
+++ b/src/dmi/icon.rs
@@ -9,7 +9,7 @@ use std::io::prelude::*;
 
 #[derive(Clone, Default)]
 pub struct Icon {
-	pub version: String,
+	pub version: DmiVersion,
 	pub width: u32,
 	pub height: u32,
 	pub states: Vec<IconState>,
@@ -268,7 +268,7 @@ impl Icon {
 		}
 
 		Ok(Icon {
-			version,
+			version: DmiVersion(version),
 			width,
 			height,
 			states,
@@ -279,7 +279,7 @@ impl Icon {
 		let mut sprites = vec![];
 		let mut signature = format!(
 			"# BEGIN DMI\nversion = {}\n\twidth = {}\n\theight = {}\n",
-			self.version, self.width, self.height
+			self.version.0, self.width, self.height
 		);
 
 		for icon_state in &self.states {
@@ -391,4 +391,11 @@ impl Default for IconState {
 			unknown_settings: None,
 		}
 	}
+}
+
+#[derive(Clone)]
+pub struct DmiVersion(String);
+
+impl Default for DmiVersion {
+	fn default() -> Self {DmiVersion("4.0".to_string())}
 }


### PR DESCRIPTION
That way when we create a new icon we can simply do something like this:
```rs
Icon {
    width: foo,
    height: bar,
    states: baz,
    ..Default::default()
}
```
And not need to specify/know the version is "4.0"