### PR TITLE
More derives on Icon helpers

### DIFF
--- a/src/dmi/icon.rs
+++ b/src/dmi/icon.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::io::prelude::*;
 use std::io::Cursor;
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, PartialEq, Debug)]
 pub struct Icon {
 	pub version: DmiVersion,
 	pub width: u32,
@@ -363,7 +363,7 @@ impl Icon {
 	}
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct IconState {
 	pub name: String,
 	pub dirs: u8,
@@ -394,7 +394,7 @@ impl Default for IconState {
 	}
 }
 
-#[derive(Clone)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct DmiVersion(String);
 
 impl Default for DmiVersion {


### PR DESCRIPTION
Add some more derives that should generally be more greedily implemented on public facing API

`PartialEq` and `Debug` on `Icon`, `PartialEq` and `Debug` on `IconState` and `Eq`, `PartialEq`, `Hash`, and `Debug` on DmiVersion