### PR TITLE
Add public direction structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ exclude = ["src/tests.rs", "tests/*"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-thiserror = "1.0"
-image = { version = "0.24.7", default-features = false, features = ["png"] }
+bitflags = "2.4.1"
 deflate = "1.0"
+image = { version = "0.24.7", default-features = false, features = ["png"] }
 inflate = "0.4.5"
+thiserror = "1.0"

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -1,0 +1,37 @@
+use bitflags::bitflags;
+
+bitflags! {
+	pub struct Dirs: u8 {
+		const NORTH =	1 << 1;
+		const SOUTH =	1 << 2;
+		const EAST =	1 << 3;
+		const WEST =	1 << 4;
+		const SOUTHEAST = Self::SOUTH.bits() | Self::EAST.bits();
+		const SOUTHWEST = Self::SOUTH.bits() | Self::WEST.bits();
+		const NORTHEAST = Self::NORTH.bits() | Self::EAST.bits();
+		const NORTHWEST = Self::NORTH.bits() | Self::WEST.bits();
+	}
+}
+
+/// A list of every cardinal direction.
+pub const CARDINAL_DIRS: [Dirs; 4] = [Dirs::NORTH, Dirs::SOUTH, Dirs::EAST, Dirs::WEST];
+
+/// A list of every ordinal direction.
+pub const ORDINAL_DIRS: [Dirs; 4] = [
+	Dirs::NORTHEAST,
+	Dirs::NORTHWEST,
+	Dirs::SOUTHEAST,
+	Dirs::SOUTHWEST,
+];
+
+/// A list of every direction, cardinals and ordinals.
+pub const ALL_DIRS: [Dirs; 8] = [
+	Dirs::NORTH,
+	Dirs::SOUTH,
+	Dirs::EAST,
+	Dirs::WEST,
+	Dirs::NORTHEAST,
+	Dirs::NORTHWEST,
+	Dirs::SOUTHEAST,
+	Dirs::SOUTHWEST,
+];

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -2,10 +2,10 @@ use bitflags::bitflags;
 
 bitflags! {
 	pub struct Dirs: u8 {
-		const NORTH =	1 << 1;
-		const SOUTH =	1 << 2;
-		const EAST =	1 << 3;
-		const WEST =	1 << 4;
+		const NORTH =	1 << 0;
+		const SOUTH =	1 << 1;
+		const EAST =	1 << 2;
+		const WEST =	1 << 3;
 		const SOUTHEAST = Self::SOUTH.bits() | Self::EAST.bits();
 		const SOUTHWEST = Self::SOUTH.bits() | Self::WEST.bits();
 		const NORTHEAST = Self::NORTH.bits() | Self::EAST.bits();

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -1,6 +1,7 @@
 use bitflags::bitflags;
 
 bitflags! {
+	/// The possible values for a direction in DM.
 	pub struct Dirs: u8 {
 		const NORTH =	1 << 0;
 		const SOUTH =	1 << 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod chunk;
 pub(crate) mod crc;
+pub mod dirs;
 pub mod error;
 pub mod icon;
 pub mod iend;


### PR DESCRIPTION
For consumers to use instead of having to re-implement dmstandard