### PR TITLE
Use `crc32fast` for CRC calculation (+ dependency updates)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,9 @@ exclude = ["src/tests.rs", "tests/*"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitflags = "2.6"
-deflate = "1.0"
-image = { version = "0.25.4", default-features = false, features = ["png"] }
-inflate = "0.4.5"
-thiserror = "1.0"
+bitflags = "2"
+crc32fast = "1"
+deflate = "1"
+image = { version = "0.25", default-features = false, features = ["png"] }
+inflate = "0.4"
+thiserror = "2"

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -60,7 +60,7 @@ impl RawGenericChunk {
 			chunk_bytes[chunk_length - 1],
 		];
 
-		let recalculated_crc = crc::calculate_crc(chunk_type.iter().chain(data.iter()));
+		let recalculated_crc = crc::calculate_chunk_data_crc(chunk_type, &data);
 		if u32::from_be_bytes(crc) != recalculated_crc {
 			let chunk_name = String::from_utf8(chunk_type.to_vec())?;
 			return Err(error::DmiError::Generic(format!("Failed to load Chunk of type {}. Supplied CRC invalid: {:#?}. Its value ({}) does not match the recalculated one ({}).", chunk_name, crc, u32::from_be_bytes(crc), recalculated_crc)));

--- a/src/crc.rs
+++ b/src/crc.rs
@@ -1,17 +1,6 @@
-pub(crate) fn calculate_crc<'a, I: IntoIterator<Item = &'a u8>>(buffer: I) -> u32 {
-	const CRC_POLYNOMIAL: u32 = 0xedb8_8320;
-
-	fn update_crc(crc: u32, message: u8) -> u32 {
-		let message: u32 = u32::from(message);
-		let mut crc = crc ^ message;
-		for _ in 0..8 {
-			crc = (if crc & 1 != 0 { CRC_POLYNOMIAL } else { 0 }) ^ (crc >> 1);
-		}
-		crc
-	}
-
-	buffer
-		.into_iter()
-		.fold(u32::MAX, |crc, message| update_crc(crc, *message))
-		^ u32::MAX
+pub(crate) fn calculate_chunk_data_crc(chunk_type: [u8; 4], data: &[u8]) -> u32 {
+	let mut hasher = crc32fast::Hasher::new();
+	hasher.update(&chunk_type);
+	hasher.update(data);
+	hasher.finalize()
 }


### PR DESCRIPTION
I changed the hand-rolled crc32 impl to just use `crc32fast` instead - outputs are identical. Just to make sure, I ran `cargo test`, and the output `tests/resources/save_test.dmi` is identical to that of the current master branch.

Profiling showed that CRC32 calcs were a noteworthy bottleneck (albeit certainly not the worst), so I thought it wouldn't hurt to switch it out for an optimized implementation.

![image](https://github.com/user-attachments/assets/22e53f41-d7c8-43ba-977e-7c989e56b293)

Also, this should avoid any extra overhead from iterators.

In addition, I updated all the dependencies.